### PR TITLE
[FEDE-3917] netty direct memory counter deprecation with bump to siren-0.14.1-6-SNAPSHOT

### DIFF
--- a/java/adapter/orc/pom.xml
+++ b/java/adapter/orc/pom.xml
@@ -86,7 +86,7 @@
     <parent>
         <groupId>org.apache.arrow</groupId>
         <artifactId>arrow-java-root</artifactId>
-        <version>siren-0.14.1-6-SNAPSHOT</version>
+        <version>siren-0.14.1-6</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/java/adapter/orc/pom.xml
+++ b/java/adapter/orc/pom.xml
@@ -86,7 +86,7 @@
     <parent>
         <groupId>org.apache.arrow</groupId>
         <artifactId>arrow-java-root</artifactId>
-        <version>siren-0.14.1-5</version>
+        <version>siren-0.14.1-6-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/java/adapter/orc/pom.xml
+++ b/java/adapter/orc/pom.xml
@@ -86,7 +86,7 @@
     <parent>
         <groupId>org.apache.arrow</groupId>
         <artifactId>arrow-java-root</artifactId>
-        <version>siren-0.14.1-6</version>
+        <version>siren-0.14.1-5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/java/adapter/orc/pom.xml
+++ b/java/adapter/orc/pom.xml
@@ -86,7 +86,7 @@
     <parent>
         <groupId>org.apache.arrow</groupId>
         <artifactId>arrow-java-root</artifactId>
-        <version>siren-0.14.1-5-SNAPSHOT</version>
+        <version>siren-0.14.1-5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/java/format/pom.xml
+++ b/java/format/pom.xml
@@ -15,7 +15,7 @@
 <parent>
   <artifactId>arrow-java-root</artifactId>
   <groupId>org.apache.arrow</groupId>
-  <version>siren-0.14.1-5-SNAPSHOT</version>
+  <version>siren-0.14.1-5</version>
 </parent>
 
 <artifactId>arrow-format</artifactId>

--- a/java/format/pom.xml
+++ b/java/format/pom.xml
@@ -15,7 +15,7 @@
 <parent>
   <artifactId>arrow-java-root</artifactId>
   <groupId>org.apache.arrow</groupId>
-  <version>siren-0.14.1-6</version>
+  <version>siren-0.14.1-5</version>
 </parent>
 
 <artifactId>arrow-format</artifactId>

--- a/java/format/pom.xml
+++ b/java/format/pom.xml
@@ -15,7 +15,7 @@
 <parent>
   <artifactId>arrow-java-root</artifactId>
   <groupId>org.apache.arrow</groupId>
-  <version>siren-0.14.1-5</version>
+  <version>siren-0.14.1-6-SNAPSHOT</version>
 </parent>
 
 <artifactId>arrow-format</artifactId>

--- a/java/format/pom.xml
+++ b/java/format/pom.xml
@@ -15,7 +15,7 @@
 <parent>
   <artifactId>arrow-java-root</artifactId>
   <groupId>org.apache.arrow</groupId>
-  <version>siren-0.14.1-6-SNAPSHOT</version>
+  <version>siren-0.14.1-6</version>
 </parent>
 
 <artifactId>arrow-format</artifactId>

--- a/java/gandiva/pom.xml
+++ b/java/gandiva/pom.xml
@@ -14,7 +14,7 @@
     <parent>
       <groupId>org.apache.arrow</groupId>
       <artifactId>arrow-java-root</artifactId>
-      <version>siren-0.14.1-5</version>
+      <version>siren-0.14.1-6-SNAPSHOT</version>
     </parent>
 
     <groupId>org.apache.arrow.gandiva</groupId>

--- a/java/gandiva/pom.xml
+++ b/java/gandiva/pom.xml
@@ -14,7 +14,7 @@
     <parent>
       <groupId>org.apache.arrow</groupId>
       <artifactId>arrow-java-root</artifactId>
-      <version>siren-0.14.1-5-SNAPSHOT</version>
+      <version>siren-0.14.1-5</version>
     </parent>
 
     <groupId>org.apache.arrow.gandiva</groupId>

--- a/java/gandiva/pom.xml
+++ b/java/gandiva/pom.xml
@@ -14,7 +14,7 @@
     <parent>
       <groupId>org.apache.arrow</groupId>
       <artifactId>arrow-java-root</artifactId>
-      <version>siren-0.14.1-6</version>
+      <version>siren-0.14.1-5</version>
     </parent>
 
     <groupId>org.apache.arrow.gandiva</groupId>

--- a/java/gandiva/pom.xml
+++ b/java/gandiva/pom.xml
@@ -14,7 +14,7 @@
     <parent>
       <groupId>org.apache.arrow</groupId>
       <artifactId>arrow-java-root</artifactId>
-      <version>siren-0.14.1-6-SNAPSHOT</version>
+      <version>siren-0.14.1-6</version>
     </parent>
 
     <groupId>org.apache.arrow.gandiva</groupId>

--- a/java/memory/pom.xml
+++ b/java/memory/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <groupId>org.apache.arrow</groupId>
     <artifactId>arrow-java-root</artifactId>
-    <version>siren-0.14.1-6-SNAPSHOT</version>
+    <version>siren-0.14.1-6</version>
   </parent>
   <artifactId>arrow-memory</artifactId>
   <name>Arrow Memory</name>

--- a/java/memory/pom.xml
+++ b/java/memory/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <groupId>org.apache.arrow</groupId>
     <artifactId>arrow-java-root</artifactId>
-    <version>siren-0.14.1-5</version>
+    <version>siren-0.14.1-6-SNAPSHOT</version>
   </parent>
   <artifactId>arrow-memory</artifactId>
   <name>Arrow Memory</name>

--- a/java/memory/pom.xml
+++ b/java/memory/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <groupId>org.apache.arrow</groupId>
     <artifactId>arrow-java-root</artifactId>
-    <version>siren-0.14.1-5-SNAPSHOT</version>
+    <version>siren-0.14.1-5</version>
   </parent>
   <artifactId>arrow-memory</artifactId>
   <name>Arrow Memory</name>

--- a/java/memory/pom.xml
+++ b/java/memory/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <groupId>org.apache.arrow</groupId>
     <artifactId>arrow-java-root</artifactId>
-    <version>siren-0.14.1-6</version>
+    <version>siren-0.14.1-5</version>
   </parent>
   <artifactId>arrow-memory</artifactId>
   <name>Arrow Memory</name>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -20,7 +20,7 @@
 
   <groupId>org.apache.arrow</groupId>
   <artifactId>arrow-java-root</artifactId>
-  <version>siren-0.14.1-6</version>
+  <version>siren-0.14.1-5</version>
   <packaging>pom</packaging>
 
   <name>Apache Arrow Java Root POM</name>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -20,7 +20,7 @@
 
   <groupId>org.apache.arrow</groupId>
   <artifactId>arrow-java-root</artifactId>
-  <version>siren-0.14.1-5</version>
+  <version>siren-0.14.1-6-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Apache Arrow Java Root POM</name>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -20,7 +20,7 @@
 
   <groupId>org.apache.arrow</groupId>
   <artifactId>arrow-java-root</artifactId>
-  <version>siren-0.14.1-5-SNAPSHOT</version>
+  <version>siren-0.14.1-5</version>
   <packaging>pom</packaging>
 
   <name>Apache Arrow Java Root POM</name>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -20,7 +20,7 @@
 
   <groupId>org.apache.arrow</groupId>
   <artifactId>arrow-java-root</artifactId>
-  <version>siren-0.14.1-6-SNAPSHOT</version>
+  <version>siren-0.14.1-6</version>
   <packaging>pom</packaging>
 
   <name>Apache Arrow Java Root POM</name>
@@ -33,7 +33,7 @@
     <dep.junit.jupiter.version>5.4.0</dep.junit.jupiter.version>
     <dep.slf4j.version>1.7.25</dep.slf4j.version>
     <dep.guava.version>20.0</dep.guava.version>
-    <dep.netty.version>siren-4.1.27-3</dep.netty.version>
+    <dep.netty.version>siren-4.1.27-4</dep.netty.version>
     <dep.jackson.version>2.9.8</dep.jackson.version>
     <dep.hadoop.version>2.7.1</dep.hadoop.version>
     <dep.fbs.version>1.9.0</dep.fbs.version>

--- a/java/vector/pom.xml
+++ b/java/vector/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <groupId>org.apache.arrow</groupId>
     <artifactId>arrow-java-root</artifactId>
-    <version>siren-0.14.1-6-SNAPSHOT</version>
+    <version>siren-0.14.1-6</version>
   </parent>
   <artifactId>arrow-vector</artifactId>
   <name>Arrow Vectors</name>

--- a/java/vector/pom.xml
+++ b/java/vector/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <groupId>org.apache.arrow</groupId>
     <artifactId>arrow-java-root</artifactId>
-    <version>siren-0.14.1-5</version>
+    <version>siren-0.14.1-6-SNAPSHOT</version>
   </parent>
   <artifactId>arrow-vector</artifactId>
   <name>Arrow Vectors</name>

--- a/java/vector/pom.xml
+++ b/java/vector/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <groupId>org.apache.arrow</groupId>
     <artifactId>arrow-java-root</artifactId>
-    <version>siren-0.14.1-5-SNAPSHOT</version>
+    <version>siren-0.14.1-5</version>
   </parent>
   <artifactId>arrow-vector</artifactId>
   <name>Arrow Vectors</name>

--- a/java/vector/pom.xml
+++ b/java/vector/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <groupId>org.apache.arrow</groupId>
     <artifactId>arrow-java-root</artifactId>
-    <version>siren-0.14.1-6</version>
+    <version>siren-0.14.1-5</version>
   </parent>
   <artifactId>arrow-vector</artifactId>
   <name>Arrow Vectors</name>


### PR DESCRIPTION
This PR provides the following
- `siren-changes` branch uses `Netty to siren-4.1.27-4`
- bumps to `siren-0.14.1-6-SNAPSHOT`
- was released as [siren-0.14.1-5](https://github.com/sirensolutions/arrow/tree/siren-0.14.1-5)