### PR TITLE
bump netty version to siren-4.1.27-5-SNAPSHOT

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -33,7 +33,7 @@
     <dep.junit.jupiter.version>5.4.0</dep.junit.jupiter.version>
     <dep.slf4j.version>1.7.25</dep.slf4j.version>
     <dep.guava.version>20.0</dep.guava.version>
-    <dep.netty.version>siren-4.1.27-4</dep.netty.version>
+    <dep.netty.version>siren-4.1.27-5-SNAPSHOT</dep.netty.version>
     <dep.jackson.version>2.9.8</dep.jackson.version>
     <dep.hadoop.version>2.7.1</dep.hadoop.version>
     <dep.fbs.version>1.9.0</dep.fbs.version>


### PR DESCRIPTION
bump netty version to siren-4.1.27-5-SNAPSHOT in order to get the MaxDirectMemorySetting changes